### PR TITLE
[Feature/api docs] 컨트롤러 테스트(api)를 문서화한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.4.3'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
+	id 'org.asciidoctor.convert' version '1.5.9.2'
 }
 
 group = 'com.example'
@@ -18,6 +19,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// restdocs
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.5.4'
+	asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor:1.2.6.RELEASE'
+	testCompile group: 'org.springframework.restdocs', name: 'spring-restdocs-mockmvc', version: '2.0.2.RELEASE'
+
 	// log
 	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
@@ -28,6 +34,22 @@ dependencies {
 
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+}
+
+ext {
+	snippetsDir = file('build/generated-snippets')
+}
+
+asciidoctor {
+	inputs.dir snippetsDir
+	dependsOn test
+}
+
+bootJar {
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}/html5") {
+		into 'static'
+	}
 }
 
 test {

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,0 +1,20 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+
+include::member.adoc[]
+
+# 예외 발생 시
+### Response
+[source,http,options="nowrap"]
+----
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{"message":"다니가 자고 있습니다."}
+----

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -1,0 +1,15 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+
+== Member(멤버)
+=== 멤버 로그인 / 회원가입
+==== Request
+include::{snippets}/member/login/http-request.adoc[]
+==== Response
+include::{snippets}/member/login/http-response.adoc[]

--- a/backend/src/test/java/wooteco/config/RestDocsConfiguration.java
+++ b/backend/src/test/java/wooteco/config/RestDocsConfiguration.java
@@ -1,0 +1,17 @@
+package wooteco.config;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@TestConfiguration
+public class RestDocsConfiguration {
+    @Bean
+    public RestDocsMockMvcConfigurationCustomizer restDocsMockMvcConfigurationCustomizer() {
+        return configurer -> configurer.operationPreprocessors()
+                .withRequestDefaults(prettyPrint())
+                .withResponseDefaults(prettyPrint());
+    }
+}

--- a/backend/src/test/java/wooteco/retrospective/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/wooteco/retrospective/presentation/member/MemberControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -16,12 +17,15 @@ import wooteco.retrospective.presentation.dto.member.MemberLoginRequest;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("회원 - Controller 테스트")
 @WebMvcTest
+@AutoConfigureRestDocs
 class MemberControllerTest {
 
     @Autowired
@@ -48,7 +52,9 @@ class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("token").value("dani"));
+                .andExpect(jsonPath("token").value("dani"))
+                .andDo(print())
+                .andDo(document("member/login"));
     }
 
     @DisplayName("로그인을 한다. - 공백 이름, 400 예외")


### PR DESCRIPTION
논의해볼 점은 다음과 같습니다.
snippet 생성 네이밍을 {domain}/{기능} 으로 하고있는데 적절한지
ex ) member/login

문서화 방법에 대해선 회의 한번 하고 리드미에 추가하겠습니다